### PR TITLE
Fix notice if width is too small

### DIFF
--- a/src/TerminalProgress/Bar.php
+++ b/src/TerminalProgress/Bar.php
@@ -225,7 +225,7 @@ class Bar
             $availableSpace = $this->width - strlen($output) + 4;
             $done = $availableSpace * ($this->percent / 100);
             $left = $availableSpace - $done;
-            $output = str_replace(':bar', str_repeat($this->symbolComplete, $done) . str_repeat($this->symbolIncomplete, $left), $output);
+            $output = str_replace(':bar', str_repeat($this->symbolComplete, max($done, 0)) . str_repeat($this->symbolIncomplete, max($left, 0)), $output);
         }
 
         fwrite($this->stream, $output);


### PR DESCRIPTION
if weight is too small (not executed shell command for get weight) and too many elements php send error: `PHP Warning: str_repeat(): Second argument has to be greater than or equal to 0`