### PR TITLE
Deprecated: Implicit conversion from float

### DIFF
--- a/src/TerminalProgress/Bar.php
+++ b/src/TerminalProgress/Bar.php
@@ -224,6 +224,7 @@ class Bar
         if (strpos($output, ':bar') !== false) {
             $availableSpace = $this->width - strlen($output) + 4;
             $done = $availableSpace * ($this->percent / 100);
+            $done = (int)$done;
             $left = $availableSpace - $done;
             $output = str_replace(':bar', str_repeat($this->symbolComplete, max($done, 0)) . str_repeat($this->symbolIncomplete, max($left, 0)), $output);
         }


### PR DESCRIPTION
When using error_reporting(E_ALL) with PHP 8.1.2 the ProgressBar sends a lot of: 

Deprecated: Implicit conversion from float 7.38 to int loses precision in ...
PHP Deprecated:  Implicit conversion from float 115.62 to int loses precision in ... 

This singe line conversion to 'int' should fix it. 